### PR TITLE
Update Makefile to solve compile error in openwrt 24.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-UUGameAcc
-PKG_VERSION:=20210806
-PKG_RELEASE:=2.13.4
+PKG_VERSION:=2.13.4
+PKG_RELEASE:=20210806
 PKG_MAINTAINER:=BCYDTZ <https://github.com/BCYDTZ/luci-app-UUGameAcc>
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
the output:

```
touch /home/zjj/openwrt/staging_dir/target-x86_64_musl/root-x86/stamp/.luci-app-UUGameAcc_installed
rm -rf /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc
mkdir -p /home/zjj/openwrt/bin/targets/x86/64/packages /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc /home/zjj/openwrt/staging_dir/target-x86_64_musl/pkginfo
install -d -m0755 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/etc/config
install -m0600 ./root/etc/config/uuplugin /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/etc/config/uuplugin
install -d -m0755 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/tmp/uuplugin
cp -pR ./root/files/* /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/tmp/uuplugin
install -d -m0755 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/etc/init.d
install -m0755 ./root/etc/init.d/uuplugin_luci /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/etc/init.d/uuplugin_luci
install -d -m0755 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/etc/uci-defaults
install -m0600 ./root/etc/uci-defaults/* /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/etc/uci-defaults
install -d -m0755 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/usr/lib/lua/luci
cp -pR ./luasrc/* /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/usr/lib/lua/luci/
install -d -m0755 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/usr/lib/lua/luci/i18n
po2lmo ./po/zh-cn/uuplugin.po /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/usr/lib/lua/luci/i18n/uuplugin.zh-cn.lmo
find /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| xargs -r rm -rf
export CROSS="x86_64-openwrt-linux-musl-"  NO_RENAME=1 ; NM="x86_64-openwrt-linux-musl-nm" STRIP="/home/zjj/openwrt/staging_dir/host/bin/sstrip -z" STRIP_KMOD="/home/zjj/openwrt/scripts/strip-kmod.sh" PATCHELF="/home/zjj/openwrt/staging_dir/host/bin/patchelf" /home/zjj/openwrt/scripts/rstrip.sh /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc
rstrip.sh: /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/tmp/uuplugin/arm/uuplugin: executable
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
rstrip.sh: /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/tmp/uuplugin/x86_64/uuplugin: executable
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
rstrip.sh: /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/tmp/uuplugin/mipsel/uuplugin: executable
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
rstrip.sh: /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/tmp/uuplugin/aarch64/uuplugin: executable
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
install -d -m0755 /home/zjj/openwrt/bin/packages/x86_64/smpackage/tmp
mkdir -p /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/
mkdir -p /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/
(cd /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc; echo "$V_Package_luci_app_UUGameAcc_postinst" > postinst-pkg; chmod 0755 postinst-pkg; echo "$V_Package_luci_app_UUGameAcc_prerm" > prerm-pkg; chmod 0755 prerm-pkg;)
( echo "#!/bin/sh"; echo "[ \"\${IPKG_NO_SCRIPT}\" = \"1\" ] && exit 0"; echo "[ -s "\${IPKG_INSTROOT}/lib/functions.sh" ] || exit 0"; echo ". \${IPKG_INSTROOT}/lib/functions.sh"; echo 'export root="${IPKG_INSTROOT}"'; echo 'export pkgname="luci-app-UUGameAcc"'; echo "add_group_and_user"; echo "default_postinst"; [ ! -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/postinst-pkg ] || sed -z 's/^\s*#!/#!/' "/home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/postinst-pkg"; ) > /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/post-install;
( echo "#!/bin/sh"; echo "[ -s "\${IPKG_INSTROOT}/lib/functions.sh" ] || exit 0"; echo ". \${IPKG_INSTROOT}/lib/functions.sh"; echo 'export root="${IPKG_INSTROOT}"'; echo 'export pkgname="luci-app-UUGameAcc"'; echo "default_prerm"; [ ! -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/prerm-pkg ] || sed -z 's/^\s*#!/#!/' "/home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/prerm-pkg"; ) > /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/pre-deinstall;
[ ! -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/postrm ] || sed -zi 's/^\s*#!/#!/' "/home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/postrm";
if [ -n "" ]; then echo  > /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.rusers; fi;
if [ -n "" ]; then echo  > /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.alternatives; fi;
(cd /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc && find . -type f,l -printf "/%P\n" > /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.list)
# Move conffiles to IDIR and build conffiles_static with csums
if [ -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/conffiles ]; then mv -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/conffiles /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.conffiles; for file in $(cat /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.conffiles); do [ -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/$file ] || continue; csum=$(/home/zjj/openwrt/staging_dir/host/bin/mkhash sha256 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/$file); echo $file $csum >> /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.conffiles_static; done; fi
# Some package (base-files) manually append stuff to conffiles
# Append stuff from it and delete the CONTROL directory since everything else should be migrated
if [ -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/CONTROL/conffiles ]; then echo $(IDIR_luci-app-UUGameAcc)/CONTROL/conffiles >> /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.conffiles; for file in $(cat /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/CONTROL/conffiles); do [ -f /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/$file ] || continue; csum=$(/home/zjj/openwrt/staging_dir/host/bin/mkhash sha256 /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/$file); echo $file $csum >> /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/lib/apk/packages/luci-app-UUGameAcc.conffiles_static; done; rm -rf /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/CONTROL/conffiles; fi
if [ -z "$(ls -A /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/CONTROL 2>/dev/null)" ]; then rm -rf /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/CONTROL; else echo "CONTROL directory /home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc/CONTROL is not empty! This is not right and should be checked!" >&2; exit 1; fi
/home/zjj/openwrt/staging_dir/host/bin/fakeroot /home/zjj/openwrt/staging_dir/host/bin/apk mkpkg --info "name:luci-app-UUGameAcc" --info "version:20210806-r2.13.4" --info "description:LuCI Support of Simple Switch to turn UUGameAcc ON/OFF" --info "arch:noarch" --info "license:" --info "origin:feeds/smpackage/luci-app-UUGameAcc" --info "url:" --info "maintainer:BCYDTZ <https://github.com/BCYDTZ/luci-app-UUGameAcc>" --info "provides:"  --script "post-install:/home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/post-install" --script "pre-deinstall:/home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/apk-all/luci-app-UUGameAcc/pre-deinstall" --info "depends:libc kmod-tun" --files "/home/zjj/openwrt/build_dir/target-x86_64_musl/luci-app-UUGameAcc-20210806/ipkg-all/luci-app-UUGameAcc" --output "/home/zjj/openwrt/bin/packages/x86_64/smpackage/luci-app-UUGameAcc-20210806-r2.13.4.apk" --sign "/home/zjj/openwrt/private-key.pem"
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: /home/zjj/openwrt/bin/packages/x86_64/smpackage/luci-app-UUGameAcc-20210806-r2.13.4.apk: package version is invalid
make[3]: *** [Makefile:118: /home/zjj/openwrt/bin/packages/x86_64/smpackage/luci-app-UUGameAcc-20210806-r2.13.4.apk] Error 99
make[3]: Leaving directory '/home/zjj/openwrt/feeds/smpackage/luci-app-UUGameAcc'
time: package/feeds/smpackage/luci-app-UUGameAcc/compile#0.35#0.30#0.68
    ERROR: package/feeds/smpackage/luci-app-UUGameAcc failed to build.
make[2]: *** [package/Makefile:185: package/feeds/smpackage/luci-app-UUGameAcc/compile] Error 1
make[2]: Leaving directory '/home/zjj/openwrt'
make[1]: *** [package/Makefile:179: /home/zjj/openwrt/staging_dir/target-x86_64_musl/stamp/.package_compile] Error 2
make[1]: Leaving directory '/home/zjj/openwrt'
make: *** [/home/zjj/openwrt/include/toplevel.mk:233: world] Error 2
``` 

重点是：
``` 
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: /home/zjj/openwrt/bin/packages/x86_64/smpackage/luci-app-UUGameAcc-20210806-r2.13.4.apk: package version is invalid
make[3]: *** [Makefile:118: /home/zjj/openwrt/bin/packages/x86_64/smpackage/luci-app-UUGameAcc-20210806-r2.13.4.apk] Error 99
``` 

我的修复后可以正常编译通过
